### PR TITLE
Move to supported ActiveDirectory library

### DIFF
--- a/src/api/ldapAPI-sample.js
+++ b/src/api/ldapAPI-sample.js
@@ -1,4 +1,4 @@
-const ActiveDirectory = require('activedirectory')
+const ActiveDirectory = require('activedirectory2')
 const Q = require('kew')
 
 var config = {


### PR DESCRIPTION
Move to supported ActiveDirectory library

"activedirectory"  is stale [https://www.npmjs.com/package/activedirectory](url), hence the need for a supported version.   Enter "activedirectory2"  [https://www.npmjs.com/package/activedirectory2](url)